### PR TITLE
add ability to pass query params as an array

### DIFF
--- a/src/api/SystemApi.ts
+++ b/src/api/SystemApi.ts
@@ -9,13 +9,17 @@ export abstract class SystemApi<Resource, CreateParams = undefined, UpdateParams
     protected apiClient: ApiClient,
   ) {}
 
-  public find(params?: Record<string, string>): Promise<TableData<Resource>> {
+  public find(params?: Record<string, string> | Array<string[]>): Promise<TableData<Resource>> {
     // TODO [Ilya] Rewrite
-    const urlSearchParams = new URLSearchParams();
+    let urlSearchParams = new URLSearchParams();
 
-    Object.keys(params || {}).forEach((key) => {
-      urlSearchParams.append(key, (params || {})[key]);
-    })
+    if (Array.isArray(params)) {
+      urlSearchParams = new URLSearchParams(params);
+    } else {
+      Object.keys(params || {}).forEach((key) => {
+        urlSearchParams.append(key, (params || {})[key]);
+      });
+    }
 
     return this.apiClient.makeCall<TableData<Resource>>(`/${this.basePath}?${urlSearchParams}`);
   }


### PR DESCRIPTION
with new API changes we need an ability to pass the same query param several times. for instance, searchByVariables=borrower_phone&searchByVariables=borrower_email. as you can see here we have searchByVariables passed two times. We cannot create an object with the same key. And URLSearchParams.append method encodes the incoming string so object {searchByVariables: 'borrower_phone&searchByVariables=borrower_email'} won't work unfortunately.
I've come up with this idea to not break anything